### PR TITLE
Aux directories get created in the wrong place

### DIFF
--- a/scripts/data/make_auxiliary_dirs.sh
+++ b/scripts/data/make_auxiliary_dirs.sh
@@ -1,7 +1,6 @@
-# cd to the path of this bash file
-parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
-
-cd "$parent_path"
+# Note that this script should NOT be run directly 
+# (e.g. with `./make_auxiliary_dirs.sh`),
+# but rather run through the Makefile (with `make aux_dirs`)
 
 echo "Creating auxiliary directories"
 mkdir -p ./data/external

--- a/scripts/data/make_auxiliary_dirs.sh
+++ b/scripts/data/make_auxiliary_dirs.sh
@@ -4,10 +4,10 @@ parent_path=$( cd "$(dirname "${BASH_SOURCE}")" ; pwd -P )
 cd "$parent_path"
 
 echo "Creating auxiliary directories"
-mkdir -p ../../data/external
-mkdir -p ../../data/interim
-mkdir -p ../../data/processed
-mkdir -p ../../data/raw
-mkdir -p ../../logs/
-mkdir -p ../../models/
+mkdir -p ./data/external
+mkdir -p ./data/interim
+mkdir -p ./data/processed
+mkdir -p ./data/raw
+mkdir -p ./logs/
+mkdir -p ./models/
 echo "Done creating auxiliary directories"


### PR DESCRIPTION
With the current instructions in the README, you are told to call make aux_dirs, which calls this script. The directories are all then created two levels too high in the tree, as they are created relative to the main directory.